### PR TITLE
Allow int as unimod ID

### DIFF
--- a/tests/UnimodMapper_test.py
+++ b/tests/UnimodMapper_test.py
@@ -31,17 +31,33 @@ CONVERSIONS = [
         "function": M.name2id,
         "cases": [{"in": {"args": ["ICAT-G:2H(8)"]}, "out": "9"}],  #
     },
-    {"function": M.id2mass, "cases": [{"in": {"args": ["9"]}, "out": 494.30142}]},  #
+    {
+        "function": M.id2mass,
+        "cases": [
+            {"in": {"args": ["9"]}, "out": 494.30142},
+            {"in": {"args": [9]}, "out": 494.30142},
+        ],
+    },  #
     {
         "function": M.id2composition,
         "cases": [
             {
                 "in": {"args": ["9"]},
                 "out": {"N": 4, "S": 1, "2H": 8, "O": 6, "C": 22, "H": 30},
-            }  #
+            },
+            {
+                "in": {"args": [9]},
+                "out": {"N": 4, "S": 1, "2H": 8, "O": 6, "C": 22, "H": 30},
+            },  #
         ],
     },
-    {"function": M.id2name, "cases": [{"in": {"args": "9"}, "out": "ICAT-G:2H(8)"}]},  #
+    {
+        "function": M.id2name,
+        "cases": [
+            {"in": {"args": ["9"]}, "out": "ICAT-G:2H(8)"},
+            {"in": {"args": [9]}, "out": "ICAT-G:2H(8)"},
+        ],
+    },  #
     {
         "function": M.mass2name_list,
         "cases": [{"in": {"args": [494.30142]}, "out": ["ICAT-G:2H(8)"]}],  #

--- a/unimod_mapper/unimod_mapper.py
+++ b/unimod_mapper/unimod_mapper.py
@@ -219,7 +219,7 @@ class UnimodMapper(object):
         Returns:
             float: Unimod mono isotopic mass
         """
-        if type(unimod_id) == int:
+        if isinstance(unimod_id, int) is True:
             unimod_id = str(unimod_id)
         return self._map_key_2_index_2_value(unimod_id, "mono_mass")
 
@@ -233,7 +233,7 @@ class UnimodMapper(object):
         Returns:
             dict: Unimod elemental composition
         """
-        if type(unimod_id) == int:
+        if isinstance(unimod_id, int) is True:
             unimod_id = str(unimod_id)
         return self._map_key_2_index_2_value(unimod_id, "element")
 
@@ -247,7 +247,7 @@ class UnimodMapper(object):
         Returns:
             str: Unimod name
         """
-        if type(unimod_id) == int:
+        if isinstance(unimod_id, int) is True:
             unimod_id = str(unimod_id)
         return self._map_key_2_index_2_value(unimod_id, "unimodname")
 

--- a/unimod_mapper/unimod_mapper.py
+++ b/unimod_mapper/unimod_mapper.py
@@ -462,7 +462,10 @@ class UnimodMapper(object):
     def _map_key_2_index_2_value(self, map_key, return_key):
         index = self.mapper.get(map_key, None)
         if index is None:
-            print("Cant map", map_key, file=sys.stderr)
+            print(
+                "Cannot map {0} while trying to return {1}".format(map_key, return_key),
+                file=sys.stderr,
+            )
             return_value = None
         else:
             return_value = self._data_list_2_value(index, return_key)

--- a/unimod_mapper/unimod_mapper.py
+++ b/unimod_mapper/unimod_mapper.py
@@ -124,8 +124,7 @@ class UnimodMapper(object):
         return data_list
 
     def _initialize_mapper(self):
-        """Set up the mapper and generate the index dict
-        """
+        """Set up the mapper and generate the index dict"""
         mapper = {}
         for index, unimod_data_dict in enumerate(self.data_list):
             for key, value in unimod_data_dict.items():
@@ -215,11 +214,13 @@ class UnimodMapper(object):
         Converts unimod ID to unimod mass
 
         Args:
-            unimod_id (int): identifier of modification
+            unimod_id (int|str): identifier of modification
 
         Returns:
             float: Unimod mono isotopic mass
         """
+        if type(unimod_id) == int:
+            unimod_id = str(unimod_id)
         return self._map_key_2_index_2_value(unimod_id, "mono_mass")
 
     def id2composition(self, unimod_id):
@@ -227,11 +228,13 @@ class UnimodMapper(object):
         Converts unimod ID to unimod composition
 
         Args:
-            unimod_id (int): identifier of modification
+            unimod_id (int|str): identifier of modification
 
         Returns:
             dict: Unimod elemental composition
         """
+        if type(unimod_id) == int:
+            unimod_id = str(unimod_id)
         return self._map_key_2_index_2_value(unimod_id, "element")
 
     def id2name(self, unimod_id):
@@ -239,11 +242,13 @@ class UnimodMapper(object):
         Converts unimod ID to unimod name
 
         Args:
-            unimod_id (int): identifier of modification
+            unimod_id (int|str): identifier of modification
 
         Returns:
             str: Unimod name
         """
+        if type(unimod_id) == int:
+            unimod_id = str(unimod_id)
         return self._map_key_2_index_2_value(unimod_id, "unimodname")
 
     # mass is ambigous therefore a list is returned


### PR DESCRIPTION
When converting a unimod ID to mass/composition/name, the unimod ID can be an integer instead of requiring a str.
This allows downwards compatibility with the previous Ursgal implementation.