### PR TITLE
Feature/unimod file handling

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pytest
+requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pytest
 requests
+loguru

--- a/unimod_mapper/unimod_mapper.py
+++ b/unimod_mapper/unimod_mapper.py
@@ -23,10 +23,11 @@ import xml.etree.ElementTree as ET
 import requests
 
 from pathlib import Path
+from loguru import logger
 
-
+# define the url from where unimod.xml file should be retrieved
 url = "http://www.unimod.org/xml/unimod.xml"
-from pathlib import Path
+
 
 class UnimodMapper(object):
     """
@@ -47,8 +48,7 @@ class UnimodMapper(object):
         self._mapper = None
 
         # Check if unimod.xml file exists & if not reset refresh_xml flag
-        xml_file_name = os.path.basename(url)
-        full_path = Path(__file__).parent / xml_file_name
+        full_path = Path(__file__).parent / "unimod.xml"
         if os.path.exists(full_path) is False:
             refresh_xml = True
 
@@ -57,7 +57,6 @@ class UnimodMapper(object):
             with open(full_path, "wb") as file:
                 file.write(response.content)
 
-        self.unimod_xml_name = xml_file_name
         self.unimod_xml_names = ["unimod.xml", "usermods.xml"]
         # self.data_list = self._parseXML()
         # self.mapper    = self._initialize_mapper()
@@ -97,11 +96,10 @@ class UnimodMapper(object):
         #         )
         #     )
         data_list = []
-        # xml_names = [self.unimod_xml_name, "usermods.xml"]
         for xml_name in self.unimod_xml_names:
             xmlFile = Path(__file__).parent / xml_name
-            print("> Parsing mods file ({0})".format(xmlFile))
             if os.path.exists(xmlFile):
+                logger.info("> Parsing mods file ({0})".format(xmlFile))
                 unimodXML = ET.iterparse(
                     codecs.open(xmlFile, "r", encoding="utf8"), events=(b"start", b"end")
                 )
@@ -138,11 +136,14 @@ class UnimodMapper(object):
                         else:
                             pass
             else:
-                if xml_name == self.unimod_xml_name:
-                    print("No unimod.xml file found. Expected at {0}".format(xmlFile))
+                if xml_name == "unimod.xml":
+                    logger.warning("No unimod.xml file found. Expected at {0}".format(
+                        xmlFile))
+                    # at least unimod.xml HAS to be available!
                     sys.exit(1)
                 elif xml_name == "usermods.xml":
-                    print("No usermods.xml file found. Expected at {0}".format(xmlFile))
+                    logger.info("No usermods.xml file found. Expected at {0}".format(
+                        xmlFile))
                     continue
         return data_list
 

--- a/unimod_mapper/unimod_mapper.py
+++ b/unimod_mapper/unimod_mapper.py
@@ -20,7 +20,12 @@ import sys
 import os
 import codecs
 import xml.etree.ElementTree as ET
+import requests
 
+from pathlib import Path
+
+
+url = "http://www.unimod.org/xml/unimod.xml"
 
 class UnimodMapper(object):
     """
@@ -36,13 +41,22 @@ class UnimodMapper(object):
 
     """
 
-    def __init__(self):
+    def __init__(self, refresh_xml=False):
         self._data_list = None
         self._mapper = None
 
-        self.unimod_xml_name = "unimod.xml"
-        # self.data_list = self._parseXML()
-        # self.mapper    = self._initialize_mapper()
+        # Check if unimod.xml file exists & if not reset refresh_xml flag
+        xml_file_name = os.path.basename(url)
+        full_path = Path(__file__).parent / xml_file_name
+        if os.path.exists(full_path) is False:
+            refresh_xml = True
+
+        if refresh_xml is True:
+            response = requests.get(url)
+            with open(full_path, "wb") as file:
+                file.write(response.content)
+
+        self.unimod_xml_name = xml_file_name
 
     @property
     def data_list(self):

--- a/unimod_mapper/unimod_mapper.py
+++ b/unimod_mapper/unimod_mapper.py
@@ -92,49 +92,54 @@ class UnimodMapper(object):
         #             os.path.dirname(__file__), "kb", "ext", self.unimod_xml_name
         #         )
         #     )
-        xmlFile = os.path.join(os.path.dirname(__file__), self.unimod_xml_name)
         data_list = []
-        print("> Parsing unimod.xml from {0}".format(xmlFile))
-        if os.path.exists(xmlFile):
-            unimodXML = ET.iterparse(
-                codecs.open(xmlFile, "r", encoding="utf8"), events=(b"start", b"end")
-            )
-            collect_element = False
-            for event, element in unimodXML:
-                if event == b"start":
-                    if element.tag.endswith("}mod"):
-                        tmp = {
-                            "unimodID": element.attrib["record_id"],
-                            "unimodname": element.attrib["title"],
-                            "element": {},
-                            "specificity_sites": [],
-                        }
-                    elif element.tag.endswith("}delta"):
-                        collect_element = True
-                        tmp["mono_mass"] = float(element.attrib["mono_mass"])
-                    elif element.tag.endswith("}element"):
-                        if collect_element is True:
-                            number = int(element.attrib["number"])
-                            if number != 0:
-                                tmp["element"][element.attrib["symbol"]] = number
-                    elif element.tag.endswith("}specificity"):
-                        amino_acid = element.attrib["site"]
-                        if element.attrib["classification"] != "Artefact":
-                            tmp["specificity_sites"].append(amino_acid)
+        xml_names = [self.unimod_xml_name, "usermods.xml"]
+        for xml_name in xml_names:
+            xmlFile = os.path.join("/Users/av568207/dev/unimod-mapper/unimod_mapper/", xml_name)
+            print("> Parsing mods file ({0})".format(xmlFile))
+            if os.path.exists(xmlFile):
+                unimodXML = ET.iterparse(
+                    codecs.open(xmlFile, "r", encoding="utf8"), events=(b"start", b"end")
+                )
+                collect_element = False
+                for event, element in unimodXML:
+                    if event == b"start":
+                        if element.tag.endswith("}mod"):
+                            tmp = {
+                                "unimodID": element.attrib["record_id"],
+                                "unimodname": element.attrib["title"],
+                                "element": {},
+                                "specificity_sites": [],
+                            }
+                        elif element.tag.endswith("}delta"):
+                            collect_element = True
+                            tmp["mono_mass"] = float(element.attrib["mono_mass"])
+                        elif element.tag.endswith("}element"):
+                            if collect_element is True:
+                                number = int(element.attrib["number"])
+                                if number != 0:
+                                    tmp["element"][element.attrib["symbol"]] = number
+                        elif element.tag.endswith("}specificity"):
+                            amino_acid = element.attrib["site"]
+                            if element.attrib["classification"] != "Artefact":
+                                tmp["specificity_sites"].append(amino_acid)
+                        else:
+                            pass
                     else:
-                        pass
-                else:
-                    # end element
-                    if element.tag.endswith("}delta"):
-                        collect_element = False
-                    elif element.tag.endswith("}mod"):
-                        data_list.append(tmp)
-                    else:
-                        pass
-
-        else:
-            print("No unimod.xml file found. Expected at {0}".format(xmlFile))
-            sys.exit(1)
+                        # end element
+                        if element.tag.endswith("}delta"):
+                            collect_element = False
+                        elif element.tag.endswith("}mod"):
+                            data_list.append(tmp)
+                        else:
+                            pass
+            else:
+                if xmlFile == self.unimod_xml_name:
+                    print("No unimod.xml file found. Expected at {0}".format(xmlFile))
+                    sys.exit(1)
+                elif xmlFile == "usermods.xml":
+                    print("No usermods.xml file found. Expected at {0}".format(xmlFile))
+                    continue
         return data_list
 
     def _initialize_mapper(self):

--- a/unimod_mapper/unimod_mapper.py
+++ b/unimod_mapper/unimod_mapper.py
@@ -26,6 +26,7 @@ from pathlib import Path
 
 
 url = "http://www.unimod.org/xml/unimod.xml"
+from pathlib import Path
 
 class UnimodMapper(object):
     """
@@ -57,6 +58,9 @@ class UnimodMapper(object):
                 file.write(response.content)
 
         self.unimod_xml_name = xml_file_name
+        self.unimod_xml_names = ["unimod.xml", "usermods.xml"]
+        # self.data_list = self._parseXML()
+        # self.mapper    = self._initialize_mapper()
 
     @property
     def data_list(self):
@@ -93,9 +97,9 @@ class UnimodMapper(object):
         #         )
         #     )
         data_list = []
-        xml_names = [self.unimod_xml_name, "usermods.xml"]
-        for xml_name in xml_names:
-            xmlFile = os.path.join("/Users/av568207/dev/unimod-mapper/unimod_mapper/", xml_name)
+        # xml_names = [self.unimod_xml_name, "usermods.xml"]
+        for xml_name in self.unimod_xml_names:
+            xmlFile = Path(__file__).parent / xml_name
             print("> Parsing mods file ({0})".format(xmlFile))
             if os.path.exists(xmlFile):
                 unimodXML = ET.iterparse(
@@ -134,10 +138,10 @@ class UnimodMapper(object):
                         else:
                             pass
             else:
-                if xmlFile == self.unimod_xml_name:
+                if xml_name == self.unimod_xml_name:
                     print("No unimod.xml file found. Expected at {0}".format(xmlFile))
                     sys.exit(1)
-                elif xmlFile == "usermods.xml":
+                elif xml_name == "usermods.xml":
                     print("No usermods.xml file found. Expected at {0}".format(xmlFile))
                     continue
         return data_list


### PR DESCRIPTION
Extracted the unimod.xml file from the repo, so it will be downloaded during __init__ if no unimod.xml is present.

Also extended the _parseXML functionality to be able to handle with unimod.xml and user_unimod.xml. This one is not yet integrated into the ursgal2 functionality but will be in the near future.